### PR TITLE
Add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Install dependencies
+        uses: Borales/actions-yarn@v2.3.0
+        with:
+          cmd: install
+
+      - name: Build
+        uses: Borales/actions-yarn@v2.3.0
+        with:
+          cmd: build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ const TITLE = "Web Analytics Handbook";
 module.exports = {
   title: TITLE,
   tagline: "개발자를 위한 웹 사용자 데이터 분석 핸드북",
-  url: "https://EveryAnalytics.github.io/web-analytics-handbook",
+  url: "https://EveryAnalytics.github.io",
   baseUrl: "/web-analytics-handbook/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",


### PR DESCRIPTION
## Description
Github Action을 사용해 배포 자동화 워크플로우를 추가했습니다.

[Docusaurus 공식문서에 소개된 방식](https://docusaurus.io/ko/docs/deployment#triggering-deployment-with-github-actions)과 다르게 built-in deploy command를 사용하지 않도록 구현했습니다. 이유는 다음과 같습니다.
1. built-in deploy command는 루트 경로의 `docusaurus.config.js`에 입력된 내용을 바탕으로 GitHub 저장소룰 찾고 소스 코드를 clone하는데, GitHub Action에선 이미 모든 코드가 checkout된 상태이기 때문에 이 과정이 필요하지 않습니다. ([참고 - docusaurus/deploy.ts](https://github.com/facebook/docusaurus/blob/master/packages/docusaurus/src/commands/deploy.ts))
2. built-in deploy command는 Git 저장소를 clone하기 위해 ssh-private-key, GIT_USER를 추가로 입력 받습니다. 당연히 add,commit,push를 위한 Credential 정보도 입력해야합니다. secret으로 관리해야할 값이 늘어나는 것은 좋지 않겠다고 생각했습니다.

결론: deploy command는 로컬에서 편하게 gh-page로 배포할 때 적합한 것 같습니다 ㅎㅎ

<br/>

✋🏻  **추가!** `docusaurus.config.js`의 url 필드에서 sub-path를 제거했습니다. 아래는 관련 warning 전문입니다. (yarn build시 발생)
```
Docusaurus config validation warning. (Field "url": the url is not supposed to contain a sub-path like '/web-analytics-handbook', please use the baseUrl field for sub-paths)
```

## Help Wanted 👀 

`secrets.GITHUB_TOKEN`이 필요합니다. 제가 권한이 없어서 ㅎㅎ.. 설정 부탁드립니다 🙇🏻 

## Related Issues

resolve #8 