### PR TITLE
GA id 환경변수로 분리

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,6 +1,8 @@
 const lightCodeTheme = require("prism-react-renderer/themes/github");
 const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 
+const PLUGINS_WEBPACK_CONFIGURE_PATH = './src/plugins/webpack-configure';
+
 const TITLE = "Web Analytics Handbook";
 
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
@@ -115,4 +117,7 @@ module.exports = {
       },
     ],
   ],
+  plugins: [
+    PLUGINS_WEBPACK_CONFIGURE_PATH,
+  ]
 };

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/react": "^17.0.16",
     "@types/react-helmet": "^6.1.2",
     "@types/react-router-dom": "^5.1.8",
+    "dotenv-webpack": "^7.0.3",
     "typescript": "^4.3.5"
   }
 }

--- a/src/plugins/webpack-configure/index.js
+++ b/src/plugins/webpack-configure/index.js
@@ -1,0 +1,22 @@
+const Dotenv = require("dotenv-webpack");
+
+const DOTENV_DEFAULT_OPTIONS = {
+  path: "./.env",
+  safe: true,
+  allowEmptyValues: false,
+  systemvars: false,
+  silent: false,
+  expand: false,
+  defaults: false,
+};
+
+module.exports = () => {
+  return {
+    name: 'evn-setting',
+    configureWebpack(config, isServer) {
+      return {
+        plugins: [new Dotenv(DOTENV_DEFAULT_OPTIONS)],
+      };
+    },
+  };
+};

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -9,16 +9,22 @@ const getGAId = () => {
   return GA_ID;
 };
 
+const createInitializeGA = () => {
+  const GA_ID = getGAId();
+  const successLog = `console.info("✅GA가 초기화 되었습니다.")`;
+  const warnningLog = `console.warn("GA가 초기화 실패되었습니다.")`;
+  return `
+    ${ GA_ID ? successLog : warnningLog }
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag("js", new Date());
+    gtag("config", "${GA_ID}");
+  `
+}
 
-const initializeGA = `
-  console.info("✅GA가 초기화 되었습니다.");
-  window.dataLayer = window.dataLayer || [];
-  function gtag() {
-    dataLayer.push(arguments);
-  }
-  gtag("js", new Date());
-  gtag("config", "G-GZ339RG282");
-`;
+const initializeGA = createInitializeGA();
 
 function Root({ children }) {
   return (

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,6 +1,15 @@
 import React from "react";
 import Head from "@docusaurus/Head";
 
+const getGAId = () => {
+  const GA_ID = process.env.REACT_APP_GA_ID;
+  if(!GA_ID) {
+    console.warn(`[web-analytics-handbook] Warnning "GA_ID" is not defined. Make sure you created the .env. And Make sure GA_ID is defined in the .env.`);
+  }
+  return GA_ID;
+};
+
+
 const initializeGA = `
   console.info("✅GA가 초기화 되었습니다.");
   window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
## Description


GA id를 환경변수에서 불러와서 사용하도록하는 함수 및 이를 사용하는 변경 사항들입니다.
1.  환경 변수 설정을 위한 webpack config 설정해주는 library install 했습니다.
2. webpack config를 docusaurus에서 사용하기 위한 plugins 구현했습니다.
3. GA_ID 가져오는 Function  구현했습니다. 
   a. GA_ID 없으면 warning 발생하도록 설계했습니다.
4. GA_ID 가져오는 Function을 사용해서 initalizeGA를 만들어주는 Function 구현했습니다.
   a. GA_ID 없으면 warning 발생하도록 설계했습니다.

## Help Wanted 👀

<!-- 도움이 필요한 부분들을 적어주세요. -->
1. getGAId, createInitalizeGA 따로 파일로 나누어서 사용해 보는게 어떨까요?!
  ex) utils/initalizeGA.js 
## Related Issues

resolve #6 

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드가 정상적으로 수행됨을 확인했습니다. (`yarn build`)
