### PR TITLE
용어사전 테이블 페이지네이션 기능 구현

### DIFF
--- a/src/components/WikiTable/WikiTable.tsx
+++ b/src/components/WikiTable/WikiTable.tsx
@@ -3,15 +3,41 @@ import React from 'react';
 import WikiTableRow from './WikiTableRow';
 
 import words from '../../../wiki.json';
+import usePagination from '../../hooks/usePagination';
 
 export default function WikiTable() {
+  const {
+    onPrevious, 
+    onNext, 
+    currentPage, 
+    result,
+    isLastPage,
+    isFirstPage
+  } = usePagination({
+    source: words,
+    offset: 2
+  });
+
   return (
-    <table>
-      <tbody>
-        {words.map((word) => (
-          <WikiTableRow key={word.name} {...word} />
-        ))}
-      </tbody>
-    </table>
+    <>
+      <span>{currentPage}</span>
+      <button 
+        onClick={onPrevious} 
+        disabled={isFirstPage}>
+        Previous
+      </button>
+      <button 
+        onClick={onNext} 
+        disabled={isLastPage}>
+        Next
+      </button>
+      <table>
+        <tbody>
+          {result.map((word) => (
+            <WikiTableRow key={word.name} {...word} />
+          ))}
+        </tbody>
+      </table>
+    </>
   );
 }

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -9,8 +9,6 @@ const usePagination = ({
   const maxPage = Math.ceil(source.length / offset);
 
   const [currentPage, setCurrentPage] = useState(initialPage);
-  const [isLastPage, setIsLastPage] = useState(false);
-  const [isFirstPage, setIsFirstPage] = useState(false);
   const [result, setResult] = useState([]);
 
   useEffect(() => {
@@ -18,8 +16,6 @@ const usePagination = ({
     const endIdx = startIdx + offset;
     
     setResult(source.slice(startIdx, endIdx));
-    setIsLastPage(currentPage === maxPage);
-    setIsFirstPage(currentPage === minPage);
   }, [currentPage]);
 
   const onPrevious = () => {
@@ -35,8 +31,8 @@ const usePagination = ({
   return {
     result,
     currentPage,
-    isLastPage,
-    isFirstPage,
+    isLastPage: currentPage === maxPage,
+    isFirstPage: currentPage === minPage,
     onPrevious,
     onNext
   };

--- a/src/hooks/usePagination.tsx
+++ b/src/hooks/usePagination.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+const usePagination = ({
+  source = [],
+  initialPage = 1,
+  offset = 10
+}) => {
+  const minPage = 1;
+  const maxPage = Math.ceil(source.length / offset);
+
+  const [currentPage, setCurrentPage] = useState(initialPage);
+  const [isLastPage, setIsLastPage] = useState(false);
+  const [isFirstPage, setIsFirstPage] = useState(false);
+  const [result, setResult] = useState([]);
+
+  useEffect(() => {
+    const startIdx = (currentPage - 1) * offset;
+    const endIdx = startIdx + offset;
+    
+    setResult(source.slice(startIdx, endIdx));
+    setIsLastPage(currentPage === maxPage);
+    setIsFirstPage(currentPage === minPage);
+  }, [currentPage]);
+
+  const onPrevious = () => {
+    if(currentPage <= minPage) return;
+    setCurrentPage(currentPage - 1);
+  };
+
+  const onNext = () => {
+    if(currentPage >= maxPage) return;
+    setCurrentPage(currentPage + 1);
+  };
+
+  return {
+    result,
+    currentPage,
+    isLastPage,
+    isFirstPage,
+    onPrevious,
+    onNext
+  };
+};
+
+export default usePagination;

--- a/wiki.json
+++ b/wiki.json
@@ -6,5 +6,33 @@
   {
     "name": "세그먼트 (Segment)",
     "description": "애널리틱스 데이터의 하위 집합. 즉, 데이터를 세분화하기 위한 수단입니다."
+  },
+  {
+    "name": "Universal Analytics",
+    "description": "구글 애널리틱스의 이전 버전으로, 현재 최신 버전은 GA4"
+  },
+  {
+    "name": "GA의 데이터 구조",
+    "description": "관리자 입장에서는 계정-속성-보기로, 사용자 입장에서는 유저-세션-히트로 나누어 생각할 수 있다."
+  },
+  {
+    "name": "Product Analytics",
+    "description": "고객이 제품에 참여하는(engage) 방식을 이해하는 데 사용하는 프로세스입니다. "
+  },
+  {
+    "name": "Session(세션)",
+    "description": "GA에서 Session은 사용자의 특정 활동 시간이며, 특정 시간안에서 사용자의 여러 상호작용의 집합입니다. (기본 설정 30분)"
+  },
+  {
+    "name": "목표(Goal)",
+    "description": "페이지/화면 조회 수, 머문 시간, 구매와 같은 비즈니스의 성공에 기여하는 완료된 액션."
+  },
+  {
+    "name": "전환(Conversion)",
+    "description": "목표로 설정된 액션이 수행되는 것. (연관: 전환율)"
+  },
+  {
+    "name": "태그(Tag)",
+    "description": "태그를 통해 외부 링크나 GA 이벤트 등을 추적할 수 있다."
   }
 ]


### PR DESCRIPTION
## Description
1. 어떻게 고쳤는가
페이지네이션 기능을 Hooks로 구현하였음

2. 왜 고쳤는가
용어 사전의 길이가 길어질 경우, 가독성에 영향을 줄 수 있음

3. TODO
현재는 non-numbering 페이지네이션, 스타일링과 함께 numbering 페이지네이션 기능 구현 예정
emotion을 적용한 스타일링 이슈는 별도 이슈를 생성하여 구현할 예정

## Related Issues
resolve [#30](https://github.com/EveryAnalytics/web-analytics-handbook/issues/30#issue-973259431)

## Checklist ✋
- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드가 정상적으로 수행됨을 확인했습니다. (`yarn build`)
