### PR TITLE
notion에 있는 용어 data 추가

### DIFF
--- a/wiki.json
+++ b/wiki.json
@@ -8,15 +8,15 @@
     "description": "애널리틱스 데이터의 하위 집합. 즉, 데이터를 세분화하기 위한 수단입니다."
   },
   {
-    "name": "이탈률(Bounce Rate)",
+    "name": "이탈률 (Bounce Rate)",
     "description": "이탈률은 처음 접근한 페이지에서 바로 떠난 비율이다."
   },
   {
-    "name": "종료율(Exit Rate)",
+    "name": "종료율 (Exit Rate)",
     "description": "종료율은 해당 페이지에서 얼마나 종료했는지를 나타내는 비율이다."
   },
   {
-    "name": "Audience(잠재 고객)",
+    "name": "Audience (잠재 고객)",
     "description": "특정 기간 동안 공통된 특성, 속성 또는 경험을 보여준 사용자 그룹/분류(Segement)"
   },
   {
@@ -24,7 +24,7 @@
     "description": "Referral은 이전 웹사이트에서 나의 웹사이트로 엑세스해 유입될 때 기록되는 이전 웹사이트의 데이터"
   },
   {
-    "name": "필터(filter)",
+    "name": "필터 (filter)",
     "description": "보기(view)에 데이터가 쌓이기 전, 특정 데이터를 걸러 내거나 통과시키는 기능"
   },
   {
@@ -64,7 +64,7 @@
     "description": "우리 웹사이트 내부가 아닌 외부의 다른 웹사이트로 연결되는 링크"
   },
   {
-    "name": "측정기준(Dimension)과 측정항목(Metrics)",
+    "name": "측정기준 (Dimension), 측정항목 (Metrics)",
     "description": "측정기준은 데이터의 속성, 측정항목은 정량적 측정 요소, 수치"
   },
   {
@@ -80,19 +80,19 @@
     "description": "고객이 제품에 참여하는(engage) 방식을 이해하는 데 사용하는 프로세스입니다. "
   },
   {
-    "name": "Session(세션)",
+    "name": "Session (세션)",
     "description": "GA에서 Session은 사용자의 특정 활동 시간이며, 특정 시간안에서 사용자의 여러 상호작용의 집합입니다. (기본 설정 30분)"
   },
   {
-    "name": "목표(Goal)",
+    "name": "목표 (Goal)",
     "description": "페이지/화면 조회 수, 머문 시간, 구매와 같은 비즈니스의 성공에 기여하는 완료된 액션."
   },
   {
-    "name": "전환(Conversion)",
+    "name": "전환 (Conversion)",
     "description": "목표로 설정된 액션이 수행되는 것. (연관: 전환율)"
   },
   {
-    "name": "태그(Tag)",
+    "name": "태그 (Tag)",
     "description": "태그를 통해 외부 링크나 GA 이벤트 등을 추적할 수 있다."
   }
 ]

--- a/wiki.json
+++ b/wiki.json
@@ -6,5 +6,61 @@
   {
     "name": "세그먼트 (Segment)",
     "description": "애널리틱스 데이터의 하위 집합. 즉, 데이터를 세분화하기 위한 수단입니다."
+  },
+  {
+    "name": "이탈률(Bounce Rate)",
+    "description": "이탈률은 처음 접근한 페이지에서 바로 떠난 비율이다."
+  },
+  {
+    "name": "종료율(Exit Rate)",
+    "description": "종료율은 해당 페이지에서 얼마나 종료했는지를 나타내는 비율이다."
+  },
+  {
+    "name": "Audience(잠재 고객)",
+    "description": "특정 기간 동안 공통된 특성, 속성 또는 경험을 보여준 사용자 그룹/분류(Segement)"
+  },
+  {
+    "name": "Referral, Self-Referrals",
+    "description": "Referral은 이전 웹사이트에서 나의 웹사이트로 엑세스해 유입될 때 기록되는 이전 웹사이트의 데이터"
+  },
+  {
+    "name": "필터(filter)",
+    "description": "보기(view)에 데이터가 쌓이기 전, 특정 데이터를 걸러 내거나 통과시키는 기능"
+  },
+  {
+    "name": "이벤트",
+    "description": "웹페이지 또는 화면 로드와는 별개로 측정할 수 있는 콘텐츠와 사용자의 상호작용"
+  },
+  {
+    "name": "Engagement",
+    "description": "사이트/앱에 방문한 유저의 모든 인터렉션"
+  },
+  {
+    "name": "Cohort",
+    "description": "유저들 중 공통적인 특징을 갖고 있어 특정 가능한 그룹"
+  },
+  {
+    "name": "Source/Medium",
+    "description": "트래픽의 오리진과 종류"
+  },
+  {
+    "name": "URL fragmentation 이슈",
+    "description": "URL fragmentation 이슈가 무엇인지 정의하고 그 해결방법을 다룹니다."
+  },
+  {
+    "name": "리마케팅 (Remarketing)",
+    "description": "사용자가 내 앱 또는 사이트에서 한 행동을 기반으로 광고를 다시 게재하는 기능"
+  },
+  {
+    "name": "권한 (Permission)",
+    "description": "관리 및 구성 작업을 처리하고, 애셋을 만들고 공유하며, 보고서 데이터를 읽고 보고서 데이터와 상호작용할 수 있는 자격"
+  },
+  {
+    "name": "Pivot Table",
+    "description": "데이터를 두 번째 차원으로 피벗하여 특정 보고서에 대한 표의 정보를 재정렬한 것으로, 측정 기준과 측정 항목으로 이루어져 있다."
+  },
+  {
+    "name": "Outbound link",
+    "description": "우리 웹사이트 내부가 아닌 외부의 다른 웹사이트로 연결되는 링크"
   }
 ]

--- a/wiki.json
+++ b/wiki.json
@@ -16,11 +16,11 @@
     "description": "종료율은 해당 페이지에서 얼마나 종료했는지를 나타내는 비율이다."
   },
   {
-    "name": "Audience (잠재 고객)",
+    "name": "잠재 고객 (Audience)",
     "description": "특정 기간 동안 공통된 특성, 속성 또는 경험을 보여준 사용자 그룹/분류(Segement)"
   },
   {
-    "name": "Referral, Self-Referrals",
+    "name": "리퍼럴 (Referral)",
     "description": "Referral은 이전 웹사이트에서 나의 웹사이트로 엑세스해 유입될 때 기록되는 이전 웹사이트의 데이터"
   },
   {
@@ -28,24 +28,16 @@
     "description": "보기(view)에 데이터가 쌓이기 전, 특정 데이터를 걸러 내거나 통과시키는 기능"
   },
   {
-    "name": "이벤트",
+    "name": "이벤트 (Event)",
     "description": "웹페이지 또는 화면 로드와는 별개로 측정할 수 있는 콘텐츠와 사용자의 상호작용"
   },
   {
-    "name": "Engagement",
+    "name": "참여 (Engagement)",
     "description": "사이트/앱에 방문한 유저의 모든 인터렉션"
   },
   {
-    "name": "Cohort",
+    "name": "코호트 (Cohort)",
     "description": "유저들 중 공통적인 특징을 갖고 있어 특정 가능한 그룹"
-  },
-  {
-    "name": "Source/Medium",
-    "description": "트래픽의 오리진과 종류"
-  },
-  {
-    "name": "URL fragmentation 이슈",
-    "description": "URL fragmentation 이슈가 무엇인지 정의하고 그 해결방법을 다룹니다."
   },
   {
     "name": "리마케팅 (Remarketing)",
@@ -56,11 +48,11 @@
     "description": "관리 및 구성 작업을 처리하고, 애셋을 만들고 공유하며, 보고서 데이터를 읽고 보고서 데이터와 상호작용할 수 있는 자격"
   },
   {
-    "name": "Pivot Table",
+    "name": "피벗 테이블 (Pivot Table)",
     "description": "데이터를 두 번째 차원으로 피벗하여 특정 보고서에 대한 표의 정보를 재정렬한 것으로, 측정 기준과 측정 항목으로 이루어져 있다."
   },
   {
-    "name": "Outbound link",
+    "name": "아웃바운드 링크 (Outbound link)",
     "description": "우리 웹사이트 내부가 아닌 외부의 다른 웹사이트로 연결되는 링크"
   },
   {
@@ -68,15 +60,15 @@
     "description": "측정기준은 데이터의 속성, 측정항목은 정량적 측정 요소, 수치"
   },
   {
-    "name": "Universal Analytics",
+    "name": "유니버셜 애널리틱스 (Universal Analytics)",
     "description": "구글 애널리틱스의 이전 버전으로, 현재 최신 버전은 GA4"
   },
   {
-    "name": "GA의 데이터 구조",
+    "name": "GA의 데이터 구조 (GA data structure)",
     "description": "관리자 입장에서는 계정-속성-보기로, 사용자 입장에서는 유저-세션-히트로 나누어 생각할 수 있다."
   },
   {
-    "name": "Product Analytics",
+    "name": "프로덕트 애널리틱스 (Product Analytics)",
     "description": "고객이 제품에 참여하는(engage) 방식을 이해하는 데 사용하는 프로세스입니다. "
   },
   {

--- a/wiki.json
+++ b/wiki.json
@@ -62,5 +62,9 @@
   {
     "name": "Outbound link",
     "description": "우리 웹사이트 내부가 아닌 외부의 다른 웹사이트로 연결되는 링크"
+  },
+  {
+    "name": "측정기준(Dimension)과 측정항목(Metrics)",
+    "description": "측정기준은 데이터의 속성, 측정항목은 정량적 측정 요소, 수치"
   }
 ]


### PR DESCRIPTION
## Description

<!-- 이 PR이 해결하는 문제. 기존의 기능을 변경한 경우, 1. 기존 기능의 작동, 2. 어떻게 고쳤는가, 3. 왜 고쳤는가를 포함해주세요. 필요에 따라 스크린샷도 첨부해주세요! -->
notion에 있는 용어집 data를 (거의전부) 추가했습니다.

## Help Wanted 👀

<!-- 도움이 필요한 부분들을 적어주세요. -->
용어등록시 용어박스 component에 들어갈 format이 필요할 것 같아요
현재 다음의 3가지 유형이 있는 것 같습니다
- 한글(영어)로 되어있는 경우
```json
{
    "name": "타이밍 (Timing)",
    "description": "사이트 내에서 함수 실행, AJAX 요청, 웹 리소스 로드 등에 걸린 시간"
 }
```
- 영어로 되어있는 경우
```json
{
    "name": "Engagement",
    "description": "사이트/앱에 방문한 유저의 모든 인터렉션"
 }
```
- 두개 이상의 용어가 있는 경우
```json
{
    "name": "측정기준(Dimension)과 측정항목(Metrics)",
    "description": "측정기준은 데이터의 속성, 측정항목은 정량적 측정 요소, 수치"
 }
```

두개 이상의 용어의 경우 따로 분리해서 설명하는 것보다 같이 설명하는 것이 이해가 더 잘가는 것 같고,
영어로만 되어 있는 경우도 있어서
name 부분에 특정 양식을 지정하지 않고 string으로 타입지정을 하는게 나을것같기도 한데 분리하는게 깔끔할 것 같기도 하고..
다들 어떻게 생각하시나요?? 좋은의견 있으면 같이 고민해보아요!!
## Related Issues

resolve #43
fix #43

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드가 정상적으로 수행됨을 확인했습니다. (`yarn build`)
