### PR TITLE
bug/123: Fix filter btn color

### DIFF
--- a/src/components/WikiSearch/LetterButtonList.tsx
+++ b/src/components/WikiSearch/LetterButtonList.tsx
@@ -45,6 +45,7 @@ const Button = styled.button`
   border: 1px solid var(--ifm-color-gray-300);
   border-radius: 4px;
   background-color: #ffffff;
+  color: #000000;
   cursor: pointer;
 
   &:hover {


### PR DESCRIPTION
* 필터의 버튼 컬러 변경
* relates to #123

## Description

핸드북 용어사전 필터 내 버튼의 폰트 컬러를 white으로 고정
이슈 참고: https://github.com/EveryAnalytics/web-analytics-handbook/issues/123

## Help Wanted 👀

* 전체 단위 컴포넌트에 대해 글로벌 스타일 적용에 대한 논의 필요
* 각 단위 컴포넌트의 background-color, color 등에 대한 개별지정은 유지보수에 있어 관리 포인트 증가
* 예시
```
button-light(default): background-color={'#ffffff'}, color={'#000000'}
button-dark: background-color={'##2e333a'}, color={'#000000'}
```

## Related Issues

resolve #123
fix #

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드가 정상적으로 수행됨을 확인했습니다. (`yarn build`)
