### PR TITLE
style: apply "Noto Sans KR" font to WAH

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,6 +6,8 @@
  */
 
 /* You can override the default Infima variables here. */
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap');
+
 :root {
   --ifm-color-primary: #51bbdd;
   --ifm-color-primary-dark: rgb(33, 175, 144);
@@ -15,6 +17,7 @@
   --ifm-color-primary-lighter: rgb(102, 212, 189);
   --ifm-color-primary-lightest: rgb(146, 224, 208);
   --ifm-code-font-size: 95%;
+  --ifm-font-family-base: 'Noto Sans KR', sans-serif;
 }
 
 .docusaurus-highlight-code-line {
@@ -24,7 +27,7 @@
   padding: 0 var(--ifm-pre-padding);
 }
 
-html[data-theme="dark"] .docusaurus-highlight-code-line {
+html[data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
 }
 


### PR DESCRIPTION
## Description
For the readability of the site, the Not Sans font was applied.

![그림3](https://user-images.githubusercontent.com/53820773/141502419-3861b805-dbc1-43e0-8479-95ddb926af3a.png)

## Related Issues

resolve #179 

## Checklist ✋
- [x] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [x] 빌드가 정상적으로 수행됨을 확인했습니다. (`yarn build`)
