### PR TITLE
fix: ChatBox dark mode color setting

### DIFF
--- a/src/components/ChatBox/index.tsx
+++ b/src/components/ChatBox/index.tsx
@@ -32,16 +32,25 @@ const ChatBox = ({
 
 const ChatContainer = styled.div`
   display: flex;
-  background: #efeeeebf;
   padding: 0.7em;
-  border-radius: 6px;
+  border-radius: 15px;
   align-items: center;
-  box-shadow: 1px 1px 6px -1px #b6b6b6;
   margin-bottom: 1em;
+  padding: 20px;
 
-  > img {
+  & > img {
     height: 2.5em;
     margin-right: 1em;
+  }
+
+  html[data-theme='light'] & {
+    background-color: #f6f7f8;
+    box-shadow: 1px 1px 5px #dddedf;
+  }
+
+  html[data-theme='dark'] & {
+    background-color: #333437;
+    box-shadow: 1px 1px 5px #2e2f31;
   }
 `;
 


### PR DESCRIPTION
## Description
![before_dark](https://user-images.githubusercontent.com/53820773/141678287-8188edbc-1942-454a-87dc-ec53e49cab43.PNG)
- dark mode일 때 ChatBox의 배경 색상과 텍스트 색상의 대비도가 낮음
- 가독성에 영향을 미칠 수 있는 부분이므로,  dark mode일 때의 색상을 따로 정의하였음
- 배경 색상값과 그림자 색상값을 마크다운의 \<pre> 스타일과 일치시킴
- 추가적으로, padding값과 borderRadius 값을 여유있게 수정하였음

light mode의 \<pre> 스타일 예시
![color_light](https://user-images.githubusercontent.com/53820773/141678332-9296ccce-e7c6-4896-b0cb-46f57b5fd526.PNG)

dark mode의 \<pre> 스타일 예시
![color_dark](https://user-images.githubusercontent.com/53820773/141678352-230734d9-6454-49fb-9d13-19bc65a1a386.PNG)


## Related Issues


resolve #184 

## Checklist ✋

<!-- PR을 생성하기 전에 아래 체크리스트를 확인해주세요. 만족한 조건들은 (`[x]`)로 표시해주세요. -->

- [ ] 모든 **변경점**들을 확인했으며 적절히 설명했습니다.
- [ ] 빌드가 정상적으로 수행됨을 확인했습니다. (`yarn build`)
